### PR TITLE
Fix the remaining lint errors

### DIFF
--- a/pkg/log/structure/merger/merged.go
+++ b/pkg/log/structure/merger/merged.go
@@ -649,7 +649,7 @@ func reorderArrayKeysForMerge(prev []string, patch []string, setElementOrderDire
 		if _, found := patchMap[directiveElem]; !found {
 			if _, found := prevMap[directiveElem]; !found {
 				// Assume the item was existing from the past
-				liveList = append(liveOnlyList, directiveElem)
+				liveList = append(liveList, directiveElem)
 			}
 		}
 	}


### PR DESCRIPTION
## os.Exit issue on the main.go

Eliminated all of the `os.Exit` calls except the one on main(). This make sure the line `defer errorreport.CheckAndReportPanic()` sent before the exit.

## append issue on `merged.go`

That seems to have a bug. Fixed it.

## body close issue on pkg/common/httpclient/retry_client_test.go

I made sure it to close the body but the lint error is still showing. I suspect it's a false positive issue.
Put a comment to ignore..